### PR TITLE
Make tests pass against Ruby 1.9

### DIFF
--- a/lib/term/ansicolor.rb
+++ b/lib/term/ansicolor.rb
@@ -77,6 +77,14 @@ module Term
     # uncoloring strings.
     COLORED_REGEXP = /\e\[(?:[34][0-7]|[0-9])?m/
 
+
+    def self.included(klass)
+      if version_is_greater_than_18? and klass == String
+        ATTRIBUTES.delete(:clear)
+        ATTRIBUTE_NAMES.delete(:clear)
+      end
+    end
+
     # Returns an uncolored version of the string, that is all
     # ANSI-sequences are stripped from the string.
     def uncolored(string = nil) # :yields:
@@ -98,5 +106,13 @@ module Term
       ATTRIBUTE_NAMES
     end
     extend self
+
+    private
+
+    def version_is_greater_than_18?
+      version = RUBY_VERSION.split('.')
+      version.map! &:to_i
+      version[0] >= 1 && version[1] > 8
+    end
   end
 end

--- a/tests/ansicolor_test.rb
+++ b/tests/ansicolor_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'test/unit'
-require 'term/ansicolor'
+require File.expand_path(File.join('lib', 'term', 'ansicolor'))
 
 class String
   include Term::ANSIColor
@@ -50,8 +50,9 @@ class ANSIColorTest < Test::Unit::TestCase
 
   def test_attributes
     foo = 'foo'
-    for (a, _) in Term::ANSIColor.attributes
-      assert_not_equal foo, foo_colored = foo.__send__(a)
+    Term::ANSIColor.attributes.each do |a, ignored|
+      foo_colored = foo.__send__(a)
+      assert_not_equal foo, foo_colored, a.inspect
       assert_equal foo, foo_colored.uncolored
       assert_not_equal foo, foo_colored = Color.__send__(a, foo)
       assert_equal foo, Color.uncolored(foo_colored)


### PR DESCRIPTION
Ruby 1.9 adds `String#clear`. This broke one of the tests when running against 1.9.2.
