### PR TITLE
version.rb file causing error because of Term::ANSIColor syntax.

### DIFF
--- a/lib/term/ansicolor/version.rb
+++ b/lib/term/ansicolor/version.rb
@@ -1,8 +1,10 @@
-module Term::ANSIColor
-  # Term::ANSIColor version
-  VERSION         = '1.0.6'
-  VERSION_ARRAY   = VERSION.split(/\./).map { |x| x.to_i } # :nodoc:
-  VERSION_MAJOR   = VERSION_ARRAY[0] # :nodoc:
-  VERSION_MINOR   = VERSION_ARRAY[1] # :nodoc:
-  VERSION_BUILD   = VERSION_ARRAY[2] # :nodoc:
+module Term
+  module ANSIColor
+    # Term::ANSIColor version
+    VERSION         = '1.0.6'
+    VERSION_ARRAY   = VERSION.split(/\./).map { |x| x.to_i } # :nodoc:
+    VERSION_MAJOR   = VERSION_ARRAY[0] # :nodoc:
+    VERSION_MINOR   = VERSION_ARRAY[1] # :nodoc:
+    VERSION_BUILD   = VERSION_ARRAY[2] # :nodoc:
+  end
 end


### PR DESCRIPTION
The version.rb file was referring directly to Term::ANSIColor instead of module Term; module ANSIColor

This means that it was failing on some versions of ruby (1.9.2 p290 for
me) because the Term module was not declared beforehand.

This was the error:
/var/lib/jenkins/.rvm/gems/ruby-1.9.2-p290/gems/term-ansicolor-1.0.6/lib/term/ansicolor/version.rb:1:in `<top (required)>': uninitialized constant Object::Term (NameError)
