### PR TITLE
Remove underscore method

### DIFF
--- a/lib/term/ansicolor/attribute/text.rb
+++ b/lib/term/ansicolor/attribute/text.rb
@@ -9,7 +9,6 @@ module Term
         Attribute.set :faint,         2
         Attribute.set :italic,        3 # not widely implemented
         Attribute.set :underline,     4
-        Attribute.set :underscore,    4 # synonym for :underline
         Attribute.set :blink,         5
         Attribute.set :rapid_blink,   6 # not widely implemented
         Attribute.set :negative,      7 # no reverse because of String#reverse


### PR DESCRIPTION
The underscore method conflicts with String.underscore from Rails.

Closes #29