### PR TITLE
Fix compatibility with the `--enable-string-literal` Ruby option

### DIFF
--- a/.all_images.yml
+++ b/.all_images.yml
@@ -9,8 +9,10 @@ script: &script |-
   echo -e "\e[0m"
   bundle
   rake test
+  rake test RUBYOPT="--enable-frozen-string-literal --debug-frozen-string-literal"
 
 images:
+  ruby:3.3-alpine: *script
   ruby:3.2-alpine: *script
   ruby:3.1-alpine: *script
   ruby:3.0-alpine: *script

--- a/lib/term/ansicolor.rb
+++ b/lib/term/ansicolor.rb
@@ -75,7 +75,7 @@ module Term
       elsif respond_to?(:to_str)
         to_str.gsub(COLORED_REGEXP, '')
       else
-        ''
+        +''
       end.extend(Term::ANSIColor)
     end
 
@@ -86,7 +86,7 @@ module Term
     # on the color +name+ is returned.
     def color(name, string = nil, &block)
       attribute = Attribute[name] or raise ArgumentError, "unknown attribute #{name.inspect}"
-      result = ''
+      result = +''
       result << "\e[#{attribute.code}m" if Term::ANSIColor.coloring?
       if block_given?
         result << yield.to_s

--- a/lib/term/ansicolor/movement.rb
+++ b/lib/term/ansicolor/movement.rb
@@ -94,6 +94,7 @@ module Term
       private
 
       def move_command(move, string = nil)
+        move = +move
         if block_given?
           move << yield.to_s
         elsif string.respond_to?(:to_str)

--- a/lib/term/ansicolor/ppm_reader.rb
+++ b/lib/term/ansicolor/ppm_reader.rb
@@ -6,7 +6,7 @@ module Term
       def initialize(io, options = {})
         @io      = io
         @options = options
-        @buffer  = ''
+        @buffer  = +''
       end
 
       def reset_io
@@ -29,7 +29,7 @@ module Term
       end
 
       def to_s
-        result = ''
+        result = +''
         each_row do |row|
           last_pixel = nil
           for pixel in row

--- a/lib/term/ansicolor/rgb_triple.rb
+++ b/lib/term/ansicolor/rgb_triple.rb
@@ -101,7 +101,7 @@ module Term
       end
 
       def html
-        s = '#'
+        s = +'#'
         @values.each { |c| s << '%02x' % c }
         s
       end

--- a/term-ansicolor.gemspec
+++ b/term-ansicolor.gemspec
@@ -3,12 +3,12 @@
 
 Gem::Specification.new do |s|
   s.name = "term-ansicolor".freeze
-  s.version = "1.7.2"
+  s.version = "1.7.2".freeze
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
   s.authors = ["Florian Frank".freeze]
-  s.date = "2024-03-15"
+  s.date = "2024-03-28"
   s.description = "This library uses ANSI escape sequences to control the attributes of terminal output".freeze
   s.email = "flori@ping.de".freeze
   s.executables = ["term_cdiff".freeze, "term_colortab".freeze, "term_decolor".freeze, "term_display".freeze, "term_mandel".freeze, "term_snow".freeze]
@@ -17,15 +17,15 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/flori/term-ansicolor".freeze
   s.licenses = ["Apache-2.0".freeze]
   s.rdoc_options = ["--title".freeze, "Term-ansicolor - Ruby library that colors strings using ANSI escape sequences".freeze, "--main".freeze, "README.md".freeze]
-  s.rubygems_version = "3.4.19".freeze
+  s.rubygems_version = "3.5.5".freeze
   s.summary = "Ruby library that colors strings using ANSI escape sequences".freeze
   s.test_files = ["tests/ansicolor_test.rb".freeze, "tests/attribute_test.rb".freeze, "tests/hsl_triple_test.rb".freeze, "tests/ppm_reader_test.rb".freeze, "tests/rgb_color_metrics_test.rb".freeze, "tests/rgb_triple_test.rb".freeze, "tests/test_helper.rb".freeze]
 
   s.specification_version = 4
 
-  s.add_development_dependency(%q<gem_hadar>.freeze, ["~> 1.14.0"])
-  s.add_development_dependency(%q<simplecov>.freeze, [">= 0"])
-  s.add_development_dependency(%q<test-unit>.freeze, [">= 0"])
-  s.add_development_dependency(%q<utils>.freeze, [">= 0"])
-  s.add_runtime_dependency(%q<tins>.freeze, ["~> 1.0"])
+  s.add_development_dependency(%q<gem_hadar>.freeze, ["~> 1.14.0".freeze])
+  s.add_development_dependency(%q<simplecov>.freeze, [">= 0".freeze])
+  s.add_development_dependency(%q<test-unit>.freeze, [">= 0".freeze])
+  s.add_development_dependency(%q<utils>.freeze, [">= 0".freeze])
+  s.add_runtime_dependency(%q<tins>.freeze, ["~> 1.0".freeze])
 end

--- a/tests/ansicolor_test.rb
+++ b/tests/ansicolor_test.rb
@@ -144,7 +144,7 @@ class ANSIColorTest < Test::Unit::TestCase
   end
 
   def test_frozen
-    string = 'foo'
+    string = +'foo'
     red = string.red
     string.extend(Term::ANSIColor).freeze
     assert string.frozen?


### PR DESCRIPTION
The `--enable-frozen-string-literal` flag has been part of Ruby for over a decade and may become the default in the semi-near future: https://bugs.ruby-lang.org/issues/20205