### PR TITLE
fix: Remove stale import for `mize`

### DIFF
--- a/lib/term/ansicolor.rb
+++ b/lib/term/ansicolor.rb
@@ -1,6 +1,5 @@
 require 'tins/xt/full'
 require 'tins/xt/ask_and_send'
-require 'mize'
 
 module Term
 


### PR DESCRIPTION
Fixes #41