### PR TITLE
Avoid requiring mize that is no longer in use

### DIFF
--- a/lib/term/ansicolor.rb
+++ b/lib/term/ansicolor.rb
@@ -1,6 +1,5 @@
 require 'tins/xt/full'
 require 'tins/xt/ask_and_send'
-require 'mize'
 
 module Term
 


### PR DESCRIPTION
Usage of mize has been dropped at eac5eeac818951392a433724572c90ba9238badb, but there remains a require to 'mize', and this causes a LoadError when mize is not bundled.

Here's a reproduction code that causes `cannot load such file -- mize (LoadError)`:
```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gem 'term-ansicolor', '1.11.1'
end

require 'term/ansicolor'
```
